### PR TITLE
test(amplify-e2e-tests): add e2e tests for hosting PROD setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -769,6 +769,13 @@ jobs:
           when: always
       - store_artifacts:
           path: ../uitest_android_results
+  hostingPROD-amplify_e2e_tests:
+    working_directory: ~/repo
+    docker: *ref_0
+    resource_class: large
+    steps: *ref_1
+    environment:
+      TEST_SUITE: src/__tests__/hostingPROD.test.ts
   plugin-amplify_e2e_tests:
     working_directory: ~/repo
     docker: *ref_0
@@ -963,6 +970,7 @@ workflows:
             - amplify_console_integration_tests
             - amplify_migration_tests_latest
             - amplify_migration_tests_v4
+            - hostingPROD-amplify_e2e_tests
             - plugin-amplify_e2e_tests
             - datastore-modegen-amplify_e2e_tests
             - interactions-amplify_e2e_tests
@@ -984,12 +992,16 @@ workflows:
                 - release
                 - master
                 - beta
-      - plugin-amplify_e2e_tests:
+      - hostingPROD-amplify_e2e_tests:
           filters: &ref_2
             branches:
               only:
                 - master
                 - split-test
+          requires:
+            - publish_to_local_registry
+      - plugin-amplify_e2e_tests:
+          filters: *ref_2
           requires:
             - publish_to_local_registry
       - datastore-modegen-amplify_e2e_tests:
@@ -1004,6 +1016,7 @@ workflows:
           filters: *ref_2
           requires:
             - publish_to_local_registry
+            - hostingPROD-amplify_e2e_tests
       - init-amplify_e2e_tests:
           filters: *ref_2
           requires:

--- a/packages/amplify-e2e-core/src/categories/hosting.ts
+++ b/packages/amplify-e2e-core/src/categories/hosting.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { nspawn as spawn, getCLIPath, createNewProjectDir, KEY_DOWN_ARROW, readJsonFile } from '../../src';
 import { spawnSync } from 'child_process';
 
-export function addHosting(cwd: string) {
+export function addDEVHosting(cwd: string) {
   return new Promise((resolve, reject) => {
     spawn(getCLIPath(), ['add', 'hosting'], { cwd, stripColors: true })
       .wait('Select the plugin module to execute')
@@ -16,6 +16,27 @@ export function addHosting(cwd: string) {
       .wait('index doc for the website')
       .sendCarriageReturn()
       .wait('error doc for the website')
+      .sendCarriageReturn()
+      .run((err: Error) => {
+        if (!err) {
+          resolve();
+        } else {
+          reject(err);
+        }
+      });
+  });
+}
+
+export function addPRODHosting(cwd: string) {
+  return new Promise((resolve, reject) => {
+    spawn(getCLIPath(), ['add', 'hosting'], { cwd, stripColors: true })
+      .wait('Select the plugin module to execute')
+      .send(KEY_DOWN_ARROW)
+      .sendCarriageReturn()
+      .wait('Select the environment setup:')
+      .send(KEY_DOWN_ARROW)
+      .sendCarriageReturn()
+      .wait('hosting bucket name')
       .sendCarriageReturn()
       .run((err: Error) => {
         if (!err) {

--- a/packages/amplify-e2e-tests/src/__tests__/hostingPROD.test.ts
+++ b/packages/amplify-e2e-tests/src/__tests__/hostingPROD.test.ts
@@ -1,7 +1,8 @@
+import { CloudFront } from 'aws-sdk';
 import { amplifyPublishWithoutUpdate, createReactTestProject, resetBuildCommand } from 'amplify-e2e-core';
 
 import { initJSProjectWithProfile, deleteProject } from 'amplify-e2e-core';
-import { addDEVHosting, removeHosting, amplifyPushWithoutCodegen } from 'amplify-e2e-core';
+import { addPRODHosting, removeHosting, amplifyPushWithoutCodegen } from 'amplify-e2e-core';
 import { deleteProjectDir, getProjectMeta } from 'amplify-e2e-core';
 import * as fs from 'fs-extra';
 import * as path from 'path';
@@ -12,7 +13,7 @@ describe('amplify add hosting', () => {
   beforeAll(async () => {
     projRoot = await createReactTestProject();
     await initJSProjectWithProfile(projRoot, {});
-    await addDEVHosting(projRoot);
+    await addPRODHosting(projRoot);
     await amplifyPushWithoutCodegen(projRoot);
   });
 
@@ -31,10 +32,14 @@ describe('amplify add hosting', () => {
     expect(fs.existsSync(path.join(projRoot, 'amplify', 'backend', 'hosting', 'S3AndCloudFront'))).toBe(true);
     const projectMeta = getProjectMeta(projRoot);
     expect(projectMeta.hosting).toBeDefined();
-    expect(projectMeta.hosting.S3AndCloudFront).toBeDefined();
+    expect(projectMeta.hosting.S3AndCloudFront).toBeDefined(); //CloudFrontDistributionID
+    expect(projectMeta.hosting.S3AndCloudFront.output.CloudFrontDistributionID).toBeDefined();
+
+    const cloudFrontDistribution = await getCloudFrontDistribution(projectMeta.hosting.S3AndCloudFront.output.CloudFrontDistributionID);
+    expect(cloudFrontDistribution.DistributionConfig.HttpVersion).toEqual('http2');
   });
 
-  it('publish successfuly', async () => {
+  it('publish successfully', async () => {
     let error;
     try {
       await amplifyPublishWithoutUpdate(projRoot);
@@ -57,3 +62,13 @@ describe('amplify add hosting', () => {
     resetBuildCommand(projRoot, currentBuildCommand);
   });
 });
+
+async function getCloudFrontDistribution(cloudFrontDistributionID: string) {
+  const cloudFrontClient = new CloudFront();
+  const getDistributionResult = await cloudFrontClient
+    .getDistribution({
+      Id: cloudFrontDistributionID,
+    })
+    .promise();
+  return getDistributionResult.Distribution;
+}


### PR DESCRIPTION
add e2e tests for hosting PROD setup, and check that CloudFront distribution configuration set the
httpVersion to http2

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.